### PR TITLE
[fix #82] changed the latex argument for setting strokeWidth

### DIFF
--- a/client/utils/latexConfig.js
+++ b/client/utils/latexConfig.js
@@ -9,7 +9,8 @@ const round = n => (Math.round(n / 50 * 10) / 10).toFixed(2)
 
 // a mapping of internal props to config options used by the latex library
 const configMap = {
-    stroke: 'color'
+    stroke: 'color',
+    strokeWidth: 'lineWidth',
 }
 
 // a mapping of propagator kinds to their equivalent in the latex library


### PR DESCRIPTION
This PR fixes a problem in the export modal which was causing an error when setting a custom width for a propagator.